### PR TITLE
disable default case for typescript files. 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -251,6 +251,7 @@ module.exports = {
         'no-extra-parens': 'off',
         'no-unused-expressions': 'off',
         'no-useless-constructor': 'off',
+        'default-case': 'off',
       }
     }
   ]


### PR DESCRIPTION
In typescript switch-exhaustiveness-check does a much better job of linting switch statements. Its already enabled but default-case overlaps and causes unnecessary defaults to be added. 

![image](https://user-images.githubusercontent.com/6200442/152050221-6f8d7368-8746-476b-9c74-33c4618679a5.png)
