### PR TITLE
Feature: using only-warn plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
   ],
   plugins: [
     'no-relative-import-paths',
+    'only-warn',
   ],
   rules: {
     '@typescript-eslint/array-type': 'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -448,6 +448,11 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.0.tgz",
       "integrity": "sha512-4if/PGGzpSP+DfOscGZ2nYd8XObc5rN9Ux5lhDzAVqLEaz8XD3ikzApSogXBdf+lnpTsTE5LJSqXFmFpNkZ3LQ=="
     },
+    "eslint-plugin-only-warn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-only-warn/-/eslint-plugin-only-warn-1.1.0.tgz",
+      "integrity": "sha512-2tktqUAT+Q3hCAU0iSf4xAN1k9zOpjK5WO8104mB0rT/dGhOa09582HN5HlbxNbPRZ0THV7nLGvzugcNOSjzfA=="
+    },
     "eslint-plugin-vue": {
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint-import-resolver-typescript": "^3.5.2",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-no-relative-import-paths": "^1.5.0",
+    "eslint-plugin-only-warn": "^1.1.0",
     "eslint-plugin-vue": "^9.7.0",
     "vue-eslint-parser": "^9.1.0"
   }


### PR DESCRIPTION
you might have noticed that since we stopped using a bunch of ts-lint rules explicitly in favor of @typescript-eslint/recommended a lot of things that used to be 'warn' and now 'error'

<img width="707" alt="image" src="https://user-images.githubusercontent.com/6098901/208116967-30219590-9078-47dc-b7d8-5872032569d4.png">

I fundamentally disagree that eslint rules should ever be 'error's. This PR introduces an eslint plugin that ensures that everything thrown will result in 'warn', leaving vscode errors for things that deserve such severity

<img width="707" alt="image" src="https://user-images.githubusercontent.com/6098901/208116571-88b6c221-3147-42a8-bc27-e00215c720ef.png">