### PR TITLE
Enhancement: Typescript switch rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -236,5 +236,12 @@ module.exports = {
         'func-call-spacing': 'off',
       }
     },
+    {
+      files: ['**/*.ts', '**/*.vue'],
+      rules: {
+        'no-case-declarations': 'off',
+        'default-case': 'off'
+      }
+    }
   ]
 }


### PR DESCRIPTION
# Description
Turning off a couple rules around switch/case that we frequently ignore because typescript has better checking for these than eslint does. 