### PR TITLE
Chore/enable downstream updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,5 @@ jobs:
         with:
           NPM_TOKEN: ${{ secrets.PREFECT_UI_COMPONENTS_NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEBULA_UI_ACTIONS_RW_TOKEN: ${{ secrets.NEBULA_UI_ACTIONS_WORKFLOWS_RW }}
+          PREFECT_OSS_ACTIONS_RW_TOKEN: ${{ secrets.PREFECT_ACTIONS_WORKFLOWS_RW }}


### PR DESCRIPTION
Update eslint release gha to allow it to initiate a downstream GHA in nebula-ui and prefect oss to update their packages upon release.
Release can be found at: TEST